### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN/App Token [SEC-58]

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -38,13 +38,6 @@ jobs:
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 16
-          
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
 
       # Calculate the next release version based on conventional semantic release
       - name: Create release branch
@@ -69,14 +62,22 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
-          
+
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "NEW_VERSION_VALUE=$new_version" >> $GITHUB_ENV
+
+      - name: Create release branch via GitHub API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Update changelog & bump version
         id: finish-release

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -85,18 +85,28 @@ jobs:
         run: |
           npm i -g conventional-changelog-cli
           SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
-          echo $SUMMARY
+          echo "$SUMMARY"
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
-          npx replace $CURRENT_VERSION_VALUE $NEW_VERSION_VALUE README.md
-          git add README.md
-          echo ${{ steps.create-release.outputs.new_version }}
+          npx replace "$CURRENT_VERSION_VALUE" "$NEW_VERSION_VALUE" README.md
+          echo "${{ steps.create-release.outputs.new_version }}"
           echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
-          npx standard-version -a
+          # Generate changelog and bump version without committing (signed-commit action will commit)
+          npx standard-version --skip.commit --skip.tag
 
-      - name: Push new version in release branch & tag
-        run: |
-          git push --follow-tags
+      - name: Create verified commit and tag via GitHub API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            README.md
+            package.json
+            package-lock.json
+          tag: 'v${{ steps.create-release.outputs.new_version }}'
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read  # to read repository contents
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feat/')
@@ -19,9 +19,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and push branches
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set Node 16
@@ -93,7 +103,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
           pr_reviewer: 'pallabmaiti'

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -27,7 +27,6 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write # to create commits, tags, and push branches
           permission-pull-requests: write # to create and update PRs
-          permission-members: read # to request team reviewers on PRs
 
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -86,15 +85,15 @@ jobs:
           HUSKY: 0
         run: |
           npm i -g conventional-changelog-cli
-          SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
-          echo "$SUMMARY"
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
           npx replace "$CURRENT_VERSION_VALUE" "$NEW_VERSION_VALUE" README.md
           echo "${{ steps.create-release.outputs.new_version }}"
-          echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
           # Generate changelog and bump version without committing (signed-commit action will commit)
           npx standard-version --skip.commit --skip.tag
+          SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
+          echo "$SUMMARY"
+          echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
 
       - name: Create verified commit and tag via GitHub API
         uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
@@ -107,7 +106,6 @@ jobs:
             CHANGELOG.md
             README.md
             package.json
-            package-lock.json
           tag: 'v${{ steps.create-release.outputs.new_version }}'
 
       - name: Create pull request into master
@@ -118,4 +116,3 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
-          pr_reviewer: '@rudderlabs/sdk-ios'

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write # to create commits, tags, and push branches
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to request team reviewers on PRs
 
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -117,4 +118,4 @@ jobs:
           github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
-          pr_reviewer: 'pallabmaiti'
+          pr_reviewer: '@rudderlabs/sdk-ios'

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: read  # to read repository contents
     name: Publish new release
     runs-on: ubuntu-latest
     if: startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true # only merged pull requests must trigger this job
@@ -17,6 +19,14 @@ jobs:
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create releases and delete branches
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -28,6 +38,7 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set Node 16
@@ -39,8 +50,8 @@ jobs:
         id: create_release
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           npx conventional-github-releaser -p angular
 


### PR DESCRIPTION
## Summary
- Migrates all PAT usages to GITHUB_TOKEN or GitHub App Token
- Adds explicit permissions at job level with comments explaining why
- Follows January 2026 best practices for GitHub Actions security
- **Uses ryancyq/github-signed-commit action for verified commits**
- **Applies new simplified pattern (removes git config, git push, uses GitHub API)**

### Files Changed
- .github/workflows/draft-new-release.yml
- .github/workflows/notion-pr-sync.yml
- .github/workflows/publish-new-release.yml

### Migration Details
| File | Token Type | Permissions | Changes |
|------|------------|-------------|---------|
| notion-pr-sync.yml | GITHUB_TOKEN | pull-requests: read | Simple read-only workflow, no App Token needed |
| draft-new-release.yml | GitHub App Token | contents: write, pull-requests: write | Creates PRs that must trigger CI checks; **uses signed-commit action for verified commits** |
| publish-new-release.yml | GitHub App Token | contents: write | Creates GitHub releases |

### Migration Pattern Evolution
1. The signed-commit action (ryancyq/github-signed-commit) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

### Code Simplifications in draft-new-release.yml
**REMOVED (no longer needed):**
- `git config user.name/email` - Signed commit uses App identity, not git config
- `git checkout -b ""` - Branch created via API
- `git push --set-upstream origin ""` - Branch created via GitHub API

**REPLACED WITH:**
- Create branch via GitHub API: `gh api repos/${{ github.repository }}/git/refs --method POST -f ref="refs/heads/$branch_name" -f sha="$BASE_SHA"`
- Use `--skip.commit --skip.tag` with standard-version
- Use ryancyq/github-signed-commit for creating verified commits and tags

**KEPT (still required):**
- `git fetch origin master` - Get latest master to merge
- `git merge origin/master` - Merge master changes locally
- `npx standard-version --skip.commit --skip.tag` - Generate changelog/versions (files only)
- `npx replace` - Modify files on disk (signed-commit reads from disk)

## Test plan
- [ ] Verify all workflows pass after merge
- [ ] Test draft-new-release workflow creates PRs with **verified commits**
- [ ] Test publish-new-release workflow creates releases correctly
- [ ] Confirm branch is created via API before signed-commit action runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)