### PR TITLE
ci(vuln): remediate GHA script injection

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -30,8 +30,10 @@ jobs:
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          BRANCH_NAME="$HEAD_REF"
           VERSION=${BRANCH_NAME#release/}
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Replaces direct ${{ github.* }} interpolation in run: blocks with env: indirection. Prevents script injection RCE via crafted branch names or other user-controlled inputs. Ref: SEC-93.